### PR TITLE
Set up plone.app.testing

### DIFF
--- a/plone/app/viewletmanager/testing.py
+++ b/plone/app/viewletmanager/testing.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from plone.app.testing import PLONE_FIXTURE
+from plone.app.testing import IntegrationTesting
+from plone.testing import Layer
+from zope.configuration import xmlconfig
+
+import doctest
+
+
+class PloneAppViewletmanagerLayer(Layer):
+
+    defaultBases = (PLONE_FIXTURE, )
+
+    def setUpZope(self, app, configurationContext):
+        # Load ZCML
+        import plone.app.viewletmanager
+        xmlconfig.file(
+            'configure.zcml',
+            plone.app.viewletmanager,
+            context=configurationContext
+        )
+
+
+PLONE_APP_VIEWLETMANAGER_FIXTURE = PloneAppViewletmanagerLayer()
+PLONE_APP_VIEWLETMANAGER_INTEGRATION_TESTING = IntegrationTesting(
+    bases=(PLONE_APP_VIEWLETMANAGER_FIXTURE, ),
+    name='PloneAppViewletmanagerLayer:Integration'
+)
+
+optionflags = doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS

--- a/plone/app/viewletmanager/tests/test_docs.py
+++ b/plone/app/viewletmanager/tests/test_docs.py
@@ -1,27 +1,25 @@
 # -*- coding: utf-8 -*-
-from zope.testing import doctest
-from zope.testing.doctestunit import DocFileSuite
+from plone.app.viewletmanager.testing import optionflags
 
-import zope.component.testing
+import doctest
+import unittest
 
 
-def tearDown(test):
-    zope.component.testing.tearDown(test)
+doc_tests = [
+    'storage.rst',
+    'manager.rst',
+]
 
 
 def test_suite():
-    from unittest import TestSuite
-    suite = TestSuite()
-    suite.addTests((
-        DocFileSuite(
-            'storage.rst',
-            tearDown=tearDown,
-            optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS,
-        ),
-        DocFileSuite(
-            'manager.rst',
-            tearDown=tearDown,
-            optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS,
-        ),
-    ))
+    suite = unittest.TestSuite()
+    suite.addTests([
+        doctest.DocFileSuite(
+            'tests/{0}'.format(doc_file),
+            package='plone.app.viewletmanager',
+            optionflags=optionflags
+        )
+        for doc_file in doc_tests
+    ])
+
     return suite

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,8 @@ long_description = '{0}\n{1}'.format(
 extras_require = {
     'test': [
         'Products.CMFPlone',
-        'Products.PloneTestCase',
+        'plone.app.testing',
         'zope.publisher',
-        'zope.testing',
     ]
 }
 


### PR DESCRIPTION
Remove all traces of `Products.PloneTestCase` and
`Testing.ZopeTestCase` from tests and instead use a
`plone.app.testing` layer.

Notice that the only change to the tests (apart from
`setUp` and `tearDown`) is a change on
`test_fragment_skip_purge`. This change (upped a
counter by one) is due to using `plone.app.testing`
which creates another viewletmanager (`Plone Default`)
by default.
