### PR TITLE
Rename _uncatched_errors to _exceptions_handled_elsewhere and add `Retry`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 2.0.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Rename ``_uncatched_errors`` to ``_exceptions_handled_elsewhere``
+  [jean]
 
 
 2.0.7 (2015-03-13)


### PR DESCRIPTION
See https://github.com/plone/plone.app.viewletmanager/issues/5

Replaces #6 which died of bitrot.