### PR TITLE
fix issue with a test in plone.app.customerize

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,9 +16,17 @@ New features:
 
 Bug fixes:
 
-- More Python 2 / 3 compatibility [ale-rt, pbauer]
-- Start making code flake8 compliant [ale-rt]
+- More Python 2 / 3 compatibility
+  [ale-rt, pbauer]
+
+- Start making code flake8 compliant
+  [ale-rt]
+
 - Tests are compliant with Products.GenericSetup >= 2.0
+
+- Fix TypeError when comparing some viewlet-types in py3.
+  [pbauer]
+
 
 2.0.11 (2018-01-30)
 -------------------

--- a/plone/app/viewletmanager/manager.py
+++ b/plone/app/viewletmanager/manager.py
@@ -4,6 +4,7 @@ from Acquisition import aq_base
 from Acquisition.interfaces import IAcquirer
 from cgi import parse_qs
 from logging import getLogger
+from operator import itemgetter
 from plone.app.viewletmanager.interfaces import IViewletManagementView
 from plone.app.viewletmanager.interfaces import IViewletSettingsStorage
 from Products.Five import BrowserView
@@ -81,7 +82,10 @@ class BaseOrderedViewletManager(object):
                 result.append((name, name_map[name]))
                 del name_map[name]
 
-        remaining = sorted(name_map.items(), key=lambda x: aq_base(x[1]))
+        try:
+            remaining = sorted(name_map.items(), key=lambda x: aq_base(x[1]))
+        except:
+            remaining = sorted(name_map.items(), key=itemgetter(0))
         # return both together
         return result + remaining
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ extras_require = {
     'test': [
         'Products.CMFPlone',
         'plone.app.testing',
+        'six',
         'zope.publisher',
     ]
 }
@@ -43,12 +44,15 @@ setup(
         'Framework :: Plone',
         "Framework :: Plone :: 5.0",
         "Framework :: Plone :: 5.1",
+        "Framework :: Plone :: 5.2",
         'Framework :: Zope2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     keywords='',
     author='Plone Foundation',


### PR DESCRIPTION
This fixes comparing some viewlets

```
    Traceback (most recent call last):
      File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest testBrowserLayers.txt[67]>", line 1, in <module>
        browser.open('http://nohost/plone/')
      File "/Users/pbauer/.cache/buildout/eggs/zope.testbrowser-5.2.4-py3.6.egg/zope/testbrowser/browser.py", line 256, in open
        self._processRequest(url, make_request)
      File "/Users/pbauer/.cache/buildout/eggs/zope.testbrowser-5.2.4-py3.6.egg/zope/testbrowser/browser.py", line 280, in _processRequest
        resp = make_request(reqargs)
      File "/Users/pbauer/.cache/buildout/eggs/zope.testbrowser-5.2.4-py3.6.egg/zope/testbrowser/browser.py", line 254, in make_request
        return self.testapp.get(url, **args)
      File "/Users/pbauer/.cache/buildout/eggs/WebTest-2.0.29-py3.6.egg/webtest/app.py", line 331, in get
        expect_errors=expect_errors)
      File "/Users/pbauer/.cache/buildout/eggs/zope.testbrowser-5.2.4-py3.6.egg/zope/testbrowser/browser.py", line 94, in do_request
        expect_errors)
      File "/Users/pbauer/.cache/buildout/eggs/WebTest-2.0.29-py3.6.egg/webtest/app.py", line 625, in do_request
        res = req.get_response(app, catch_exc_info=True)
      File "/Users/pbauer/.cache/buildout/eggs/WebOb-1.8.1-py3.6.egg/webob/request.py", line 1309, in send
        application, catch_exc_info=True)
      File "/Users/pbauer/.cache/buildout/eggs/WebOb-1.8.1-py3.6.egg/webob/request.py", line 1277, in call_application
        app_iter = application(self.environ, start_response)
      File "/Users/pbauer/.cache/buildout/eggs/WebTest-2.0.29-py3.6.egg/webtest/lint.py", line 200, in lint_app
        iterator = application(environ, start_response_wrapper)
      File "/Users/pbauer/workspace/plip/src/plone.testing/src/plone/testing/_z2_testbrowser.py", line 38, in wrapped_func
        return func(*args, **kw)
      File "/Users/pbauer/workspace/plip/src/plone.testing/src/plone/testing/_z2_testbrowser.py", line 65, in __call__
        wsgi_result = publish(environ, start_response)
      File "/Users/pbauer/workspace/plip/src/Zope/src/ZPublisher/WSGIPublisher.py", line 270, in publish_module
        response = _publish(request, new_mod_info)
      File "/Users/pbauer/workspace/plip/src/Zope/src/ZPublisher/WSGIPublisher.py", line 210, in publish
        bind=1)
      File "/Users/pbauer/workspace/plip/src/Zope/src/ZPublisher/mapply.py", line 85, in mapply
        return debug(object, args, context)
      File "/Users/pbauer/workspace/plip/src/Zope/src/ZPublisher/WSGIPublisher.py", line 57, in call_object
        return obj(*args)
      File "/Users/pbauer/.cache/buildout/eggs/zope.browserpage-4.2.0-py3.6.egg/zope/browserpage/simpleviewclass.py", line 41, in __call__
        return self.index(*args, **kw)
      File "/Users/pbauer/workspace/plip/src/Zope/src/Products/Five/browser/pagetemplatefile.py", line 125, in __call__
        return self.__func__(__self__, *args, **kw)
      File "/Users/pbauer/workspace/plip/src/Zope/src/Products/Five/browser/pagetemplatefile.py", line 60, in __call__
        sourceAnnotations=getattr(debug_flags, 'sourceAnnotations', 0),
      File "/Users/pbauer/.cache/buildout/eggs/zope.pagetemplate-4.3.0-py3.6.egg/zope/pagetemplate/pagetemplate.py", line 134, in pt_render
        strictinsert=0, sourceAnnotations=sourceAnnotations
      File "/Users/pbauer/workspace/plip/src/Zope/src/Products/PageTemplates/engine.py", line 85, in __call__
        return self.template.render(**kwargs)
      File "/Users/pbauer/.cache/buildout/eggs/z3c.pt-3.1.0-py3.6.egg/z3c/pt/pagetemplate.py", line 158, in render
        return base_renderer(**context)
      File "/Users/pbauer/workspace/plip/src/chameleon/src/chameleon/zpt/template.py", line 297, in render
        return super(PageTemplate, self).render(**_kw)
      File "/Users/pbauer/workspace/plip/src/chameleon/src/chameleon/template.py", line 191, in render
        raise_with_traceback(exc, tb)
      File "/Users/pbauer/workspace/plip/src/chameleon/src/chameleon/utils.py", line 75, in raise_with_traceback
        raise exc
      File "/Users/pbauer/workspace/plip/src/chameleon/src/chameleon/template.py", line 171, in render
        self._render(stream, econtext, rcontext)
      File "bdf84bc1bb3b583d7c81f299be8d49ec.py", line 1299, in render
      File "522672d104e82e0cfca99049e129f067.py", line 836, in render_master
      File "/Users/pbauer/.cache/buildout/eggs/z3c.pt-3.1.0-py3.6.egg/z3c/pt/expressions.py", line 69, in render_content_provider
        cp.update()
      File "/Users/pbauer/.cache/buildout/eggs/zope.viewlet-4.1.0-py3.6.egg/zope/viewlet/manager.py", line 104, in update
        viewlets = self.sort(viewlets)
      File "/Users/pbauer/workspace/plip/src/plone.app.viewletmanager/plone/app/viewletmanager/manager.py", line 84, in sort
        remaining = sorted(name_map.items(), key=lambda x: aq_base(x[1]))
    TypeError: '<' not supported between instances of 'TTWViewletRenderer' and 'AnalyticsViewlet'

     - Expression: "provider:plone.portalfooter"
     - Filename:   ... one/Products/CMFPlone/browser/templates/main_template.pt
     - Location:   (line 146: col 34)
     - Source:     ...
                                           ^
     - Expression: "context/main_template/macros/master"
     - Filename:   ... .dexterity/plone/app/dexterity/browser/folder_listing.pt
     - Location:   (line 6: col 21)
     - Source:     ... etal:use-macro="context/main_template/macros/master"
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     - Arguments:  template: <ViewPageTemplateFile - at 0x10b41e5f8>
                   options: {...} (0)
                   args: <tuple - at 0x105c61048>
                   nothing: <NoneType - at 0x105b719f8>
                   modules: <_SecureModuleImporter - at 0x1079a2128>
                   request: <WSGIRequest - at 0x1078fedd8>
                   view: <SimpleViewClass from /Users/pbauer/workspace/plip/src/plone.app.dexterity/plone/app/dexterity/browser/folder_listing.pt folder_listing at 0x10791a978>
                   context: <ImplicitAcquisitionWrapper plone at 0x10bfe8438>
                   views: <ViewMapper - at 0x10791a630>
                   here: <ImplicitAcquisitionWrapper plone at 0x10bfe8438>
                   container: <ImplicitAcquisitionWrapper plone at 0x10bfe8438>
                   root: <ImplicitAcquisitionWrapper  at 0x10bfe8120>
                   traverse_subpath: <list - at 0x10e7a8608>
                   user: <ImplicitAcquisitionWrapper - at 0x10b89d288>
                   default: <object - at 0x105cdc8f0>
                   repeat: {...} (0)
                   loop: {...} (0)
                   wrapped_repeat: <SafeMapping - at 0x10e226388>
                   target_language: en
                   translate: <function translate at 0x107909730>
                   macroname: master
```