### PR TITLE
Fix deprecation warning importing ZPublisher.Retry

### DIFF
--- a/news/19.bugfix
+++ b/news/19.bugfix
@@ -1,0 +1,1 @@
+Fix deprecation warning importing ZPublisher.Retry

--- a/plone/app/viewletmanager/manager.py
+++ b/plone/app/viewletmanager/manager.py
@@ -20,7 +20,7 @@ from zope.contentprovider.interfaces import IContentProvider
 from zope.interface import implementer
 from zope.interface import providedBy
 from zope.viewlet.interfaces import IViewlet
-from ZPublisher.Publish import Retry
+from ZPublisher import Retry
 
 
 logger = getLogger('plone.app.viewletmanager')


### PR DESCRIPTION
The import is deprecated since 3 years:

- https://github.com/zopefoundation/Zope/commit/2f444231fc9ff9f28691b411629a377af160d1c6#diff-3f8ad2e4a0738b415cb2c41ff71d59b9R38

Fixes #19