### PR TITLE
Update markup to use Bootstrap Cards

### DIFF
--- a/news/26.bugfix
+++ b/news/26.bugfix
@@ -1,0 +1,2 @@
+Update markup due to disabled Diazo rules for this view
+  [santonelli]

--- a/plone/app/viewletmanager/manage-viewletmanager.pt
+++ b/plone/app/viewletmanager/manage-viewletmanager.pt
@@ -1,33 +1,52 @@
-<div class="managedViewlets" tal:attributes="id view/normalized_name"
-     i18n:domain="plone">
-    <dl class="viewletmanager" tal:define="auth_token context/@@authenticator/token | nothing">
-        <dt>
-            ViewletManager: <span tal:content="view/name">ViewletManager name</span>
-            (<span tal:content="view/interface" />)
-        </dt>
-        <dd>
-            <dl tal:repeat="viewlet options/viewlets"
-                tal:attributes="class python:'viewlet %s' % (viewlet['hidden'] and 'hiddenViewlet' or '')">
-                <dt>
-                    Viewlet: <span tal:replace="viewlet/name">Viewlet name</span>
-                    (<span tal:replace="viewlet/index">Index</span>)
-                    <a class="up"
-                       tal:condition="viewlet/up_url | nothing"
-                       tal:attributes="href string:${viewlet/up_url}&_authenticator=${auth_token}">&#9650;</a>
-                    <a class="down"
-                       tal:condition="viewlet/down_url | nothing"
-                       tal:attributes="href string:${viewlet/down_url}&_authenticator=${auth_token}">&#9660;</a>
-                    <a class="hide"
-                       i18n:translate="label_hide_item"
-                       tal:attributes="href string:${viewlet/hide_url}&_authenticator=${auth_token}">Hide</a>
-                    <a class="show"
-                       i18n:translate="label_show_item"
-                       tal:attributes="href string:${viewlet/show_url}&_authenticator=${auth_token}">Show</a>
-                </dt>
-                <dd class="clearfix">
-                    <div tal:replace="structure viewlet/content"></div>
-                </dd>
-            </dl>
-        </dd>
-    </dl>
+<div class="container mb-3">
+
+  <div class="managedViewlets" tal:attributes="id view/normalized_name" i18n:domain="plone">
+
+    <div class="card" tal:define="auth_token context/@@authenticator/token | nothing">
+
+      <div class="card-header">
+        ViewletManager <span class="text-muted" tal:content="view/name">ViewletManager name</span> (<span tal:content="view/interface" />)
+      </div>
+
+      <div class="card-body">
+
+        <div tal:repeat="viewlet options/viewlets" tal:attributes="class python:'viewlet %s' % (viewlet['hidden'] and 'hiddenViewlet' or '')">
+
+          <div class="card mb-3">
+
+            <div class="card-header d-flex">
+
+              <div class="me-auto">
+                Viewlet <span class="text-muted" tal:content="viewlet/name">Viewlet name</span> (<span tal:replace="viewlet/index">Index</span>)
+              </div>
+
+              <a class="btn btn-sm btn-outline-primary up mx-1 text-decoration-none" tal:condition="viewlet/up_url | nothing" tal:attributes="href string:${viewlet/up_url}&_authenticator=${auth_token}">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-up-short" viewBox="0 0 16 16">
+                  <path fill-rule="evenodd" d="M8 12a.5.5 0 0 0 .5-.5V5.707l2.146 2.147a.5.5 0 0 0 .708-.708l-3-3a.5.5 0 0 0-.708 0l-3 3a.5.5 0 1 0 .708.708L7.5 5.707V11.5a.5.5 0 0 0 .5.5z"/>
+                </svg>
+              </a>
+              <a class="btn btn-sm btn-outline-primary down mx-1 text-decoration-none" tal:condition="viewlet/down_url | nothing" tal:attributes="href string:${viewlet/down_url}&_authenticator=${auth_token}">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-down-short" viewBox="0 0 16 16">
+                  <path fill-rule="evenodd" d="M8 4a.5.5 0 0 1 .5.5v5.793l2.146-2.147a.5.5 0 0 1 .708.708l-3 3a.5.5 0 0 1-.708 0l-3-3a.5.5 0 1 1 .708-.708L7.5 10.293V4.5A.5.5 0 0 1 8 4z"/>
+                </svg>
+              </a>
+              <a class="btn btn-sm btn-outline-primary hide mx-1 text-decoration-none" i18n:translate="label_hide_item" tal:attributes="href string:${viewlet/hide_url}&_authenticator=${auth_token}">Hide</a>
+              <a class="btn btn-sm btn-outline-primary show mx-1 text-decoration-none" i18n:translate="label_show_item" tal:attributes="href string:${viewlet/show_url}&_authenticator=${auth_token}">Show</a>
+
+            </div>
+
+            <div class="card-body">
+              <div tal:replace="structure viewlet/content"></div>
+            </div>
+
+          </div>
+
+        </div>
+
+      </div>
+
+    </div>
+
+  </div>
+
 </div>

--- a/plone/app/viewletmanager/manage-viewlets.pt
+++ b/plone/app/viewletmanager/manage-viewlets.pt
@@ -14,7 +14,7 @@
                             e.preventDefault();
                             var url = $(e.currentTarget).attr('href'),
                                 vm = $(e.delegateTarget);
-                            $(vm).load(url + ' #' + $(vm).attr('id') + '.managedViewlets > dl');
+                            $(vm).load(url + ' #' + $(vm).attr('id') + '.managedViewlets > div');
                       });
                   });
               })(jQuery);
@@ -25,43 +25,46 @@
 <metal:main fill-slot="main">
 
     <style type="text/css" media="screen">
-        .viewletmanager, .viewlet { display: block; margin: .5em;}
-        .viewletmanager { border: 1px solid #000;}
-        .viewletmanager > dt { border-bottom: 1px solid #000; }
-        .viewletmanager > dt, .viewlet > dt { font-size: .8em; background: #EEE; padding: .5em; }
-        .viewlet { border: 1px solid #999; }
-        .viewlet > dt { border-bottom: 1px solid #999; }
-        .viewlet > dt > a.show { display: none !important; }
-        .viewlet > dt > a.hide { display: inline !important; }
-        .viewletmanager dd, .viewlet dd { padding: .5em; }
-        .viewlet.hiddenViewlet { opacity: 0.5; }
-        .viewlet.hiddenViewlet > dt > a.hide { display:none !important; }
-        .viewlet.hiddenViewlet > dt > a.show { display: inline !important; }
+        #portal-top { margin-top: 1em; }
+        #portal-footer-wrapper { background-color: unset; color: unset; text-align: left; padding: 0; }
+        #plone-toolbar { padding-top: 1em; }        
+        #plone-toolbar .card-header { color: #000; }
+        #plone-toolbar .card-body { background-color: #333; }
+        #plone-toolbar .d-flex { display: block; }
+        #plone-toolbar .btn { margin: 5px 5px 0 0; }
     </style>
 
-    <div tal:replace="structure provider:plone.abovecontenttitle" />
+    <div class="xcontainer">
 
-    <h1 class="documentFirstHeading"
-        i18n:translate="label_title">
-      Title
-    </h1>
+        <div tal:replace="structure provider:plone.abovecontenttitle" />
 
-    <div tal:replace="structure provider:plone.belowcontenttitle" />
+        <div class="container my5">
+          <h1 class="" i18n:translate="label_title">
+              Title
+          </h1>
+        </div>
 
-    <div class="documentDescription"
-       i18n:translate="label_description">
-        Summary
+        <div tal:replace="structure provider:plone.belowcontenttitle" />
+
+        <div class="container my-5">
+          <div class="lead" i18n:translate="label_description">
+              Summary
+          </div>
+        </div>
+
+        <div tal:replace="structure provider:plone.abovecontentbody" />
+
+        <div class="container my-5">
+          <div id="content-core">
+              <p>
+                  This item does not have any body text, click the edit tab to change it.
+              </p>
+          </div>
+        </div>
+
+        <div tal:replace="structure provider:plone.belowcontentbody" />
+    
     </div>
-
-    <div tal:replace="structure provider:plone.abovecontentbody" />
-
-    <div id="content-core">
-        <p>
-            This item does not have any body text, click the edit tab to change it.
-        </p>
-    </div>
-
-    <div tal:replace="structure provider:plone.belowcontentbody" />
 
 </metal:main>
 


### PR DESCRIPTION
Due to [disabled Diazo rules](https://github.com/plone/plonetheme.barceloneta/pull/303). Styling fixes are mostly for the toolbar and may go to Barceloneta.

### Preview

<img width="1440" alt="Screenshot 2022-09-01 at 11 29 32" src="https://user-images.githubusercontent.com/4093825/187882142-48d3505e-190d-4353-939a-840a4bfd1ab5.png">
