### PR TITLE
Only show one Hide or Show button per viewlet on manage-viewlets

### DIFF
--- a/news/3831.bugfix
+++ b/news/3831.bugfix
@@ -1,0 +1,3 @@
+Only show one Hide or Show button per viewlet on the manage-viewlets page.
+Make it clear that a viewlet is hidden by making it more subdued / opaque.
+[maurits]

--- a/plone/app/viewletmanager/manage-viewletmanager.pt
+++ b/plone/app/viewletmanager/manage-viewletmanager.pt
@@ -27,7 +27,7 @@
 
       <div class="card-body">
 
-        <div class="${python:'viewlet %s' % ('hiddenViewlet' if viewlet['hidden'] else '')}"
+        <div class="${python:'viewlet %s' % ('opacity-50' if viewlet['hidden'] else '')}"
              tal:repeat="viewlet options/viewlets"
         >
 
@@ -77,11 +77,11 @@
                   ></path>
                 </svg>
               </a>
-              <a class="btn btn-sm btn-outline-primary mx-1 text-decoration-none pat-inject ${python:'active' if not viewlet['hidden'] else ''}"
+              <a class="btn btn-sm btn-outline-primary mx-1 text-decoration-none pat-inject ${python:'' if not viewlet['hidden'] else 'd-none'}"
                  href="${viewlet/hide_url}&amp;_authenticator=${auth_token}#${manager_id}"
                  i18n:translate="label_hide_item"
               >Hide</a>
-              <a class="btn btn-sm btn-outline-primary mx-1 text-decoration-none pat-inject ${python:'active' if viewlet['hidden'] else ''}"
+              <a class="btn btn-sm btn-outline-primary mx-1 text-decoration-none pat-inject ${python:'' if viewlet['hidden'] else 'd-none'}"
                  href="${viewlet/show_url}&amp;_authenticator=${auth_token}#${manager_id}"
                  i18n:translate="label_show_item"
               >Show</a>


### PR DESCRIPTION
And make it clear that a viewlet is hidden by making it more subdued / opaque.

This fixes https://github.com/plone/Products.CMFPlone/issues/3831.
See there for screen shots before and after, and for comparison also Plone 5.2.